### PR TITLE
Added .travis.yml to .Rbuildignore

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -6,3 +6,4 @@
 CONDUCT.md
 CONTRIBUTING.md
 img
+.travis.yml


### PR DESCRIPTION
It seems to cause travis to fail, because it generates error when building the R package.